### PR TITLE
feat: finilize the kubernates config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
         run: TAG=$(echo $GITHUB_SHA | head -c7) && sed -i 's|<IMAGE>|registry.digitalocean.com/earthpoints/earthpoints-poc:'${TAG}'|' $GITHUB_WORKSPACE/kuber.yml
 
       - name: Save DigitalOcean kubeconfig with short-lived credentials
-        run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 a9bf339a-f24e-4eff-a614-8b2a73ffadfe
+        run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 ffb1a5d5-e0c7-4553-87d2-db6633465a6d
 
       - name: Deploy to DigitalOcean Kubernetes
         run: kubectl apply -f $GITHUB_WORKSPACE/kuber.yml

--- a/kuber.yml
+++ b/kuber.yml
@@ -1,3 +1,17 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: cassandra-claim0
+  name: cassandra-claim0
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20,10 +34,22 @@ spec:
         app: earthpoints-poc
     spec:
       containers:
+        - name: cassandra
+          image: cassandra:4.0
+          env:
+            - name: CASSANDRA_CLUSTER_NAME
+              value: earthpoints          
+          ports:
+            - containerPort: 9042
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /var/lib/cassandra
+              name: cassandra-volume
         - name: earthpoints-poc
           image: <IMAGE>
           ports:
             - containerPort: 3000
+              protocol: TCP
           resources:
             requests:
               cpu: 100m
@@ -32,18 +58,31 @@ spec:
           envFrom:
           - secretRef:
               name: earthpoints-poc-secret
+      volumes:
+        - name: cassandra-volume
+          persistentVolumeClaim:
+            claimName: cassandra-claim0
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: earthpoints-poc-service
+  annotations:
+    service.beta.kubernetes.io/do-loadbalancer-name: "earthpoints-poc-service"
+    service.beta.kubernetes.io/do-loadbalancer-protocol: "http"
+    service.beta.kubernetes.io/do-loadbalancer-tls-ports: "443"
+    service.beta.kubernetes.io/do-loadbalancer-certificate-id: "20f424dd-149c-494a-92f6-f71683af0b47"
+    service.beta.kubernetes.io/do-loadbalancer-disable-lets-encrypt-dns-records: "false"
+    service.beta.kubernetes.io/do-loadbalancer-redirect-http-to-https: "true"
 spec:
   type: LoadBalancer
   ports:
     - name: http
+      protocol: TCP
       port: 80
       targetPort: 3000
     - name: https
+      protocol: TCP
       port: 443
       targetPort: 3000
   selector:

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,19 +11,20 @@ import cookieParser from 'cookie-parser';
 import { engine } from "express-handlebars";
 
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { NestApplicationOptions } from '@nestjs/common';
 
 dotenv.config();
 
 async function bootstrap() {
   const fs = require('fs');
-  const keyFile  = fs.readFileSync(process.env.NEST_APP_KEY_PATH);
-  const certFile = fs.readFileSync(process.env.NEST_APP_CERT_PATH);
+  const keyFile = process.env.NEST_APP_KEY_PATH && fs.readFileSync(process.env.NEST_APP_KEY_PATH);
+  const certFile = process.env.NEST_APP_CERT_PATH && fs.readFileSync(process.env.NEST_APP_CERT_PATH);
+  let options: NestApplicationOptions;
+  if(keyFile && certFile)
+    options = {httpsOptions : {key: keyFile, cert: certFile}};
 
-  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
-    httpsOptions: {
-      key: keyFile,
-      cert: certFile,
-    }});
+
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, options);
   const viewsPath = join(__dirname, '../public/views'); 
   app.engine('.hbs', engine({ extname: '.hbs', defaultLayout: 'main' }));
   app.use(cookieParser());


### PR DESCRIPTION
- nest app secure connection made optional

please note that I needed the nest app key file read process optional. In development, we are going to need secure connections. However in live under kubernates, the container has to accept non secure connection from the environment's load balancer only. We have moved the configuration of secure connection to loadbalancer. So between LB and container does not need to be secure. By removing or adding the key file path environment variables (NEST_APP_KEY_PATH,NEST_APP_CERT_PATH), the nest can be secure or not.