### PR TITLE
Add 'email' to facebook strategy scope in addition to profileFields

### DIFF
--- a/src/auth/facebook.strategy.ts
+++ b/src/auth/facebook.strategy.ts
@@ -23,7 +23,7 @@ export class FacebookStrategy extends PassportStrategy(Strategy, 'facebook') {
       clientID: process.env.FACEBOOK_APP_ID || 'x',
       clientSecret: process.env.FACEBOOK_APP_SECRET || 'x',
       callbackURL: process.env.FACEBOOK_CALLBACK_URL || 'x',
-      scope: ['user_posts'],
+      scope: ['user_posts', 'email'],
       profileFields: ['name', 'email'],
       passReqToCallback: true
     });


### PR DESCRIPTION
to retrieve emails for non-admin users

(facebook api v3.2 requires the 'email' scope for this)