### PR TITLE
fix: before rewarding for platform connection checks if it is rewardr…

### DIFF
--- a/src/point-event/point-event.controller.ts
+++ b/src/point-event/point-event.controller.ts
@@ -39,7 +39,7 @@ export class PointEventController {
   @UseGuards(AdminOnlyGuard)
   @UseGuards(JwtAuthGuard)
   findOne(@Param('id') id: string) {
-    return this.pointEventService.findOne(+id);
+    return this.pointEventService.findOne(id);
   }
 
   @Patch(':id')

--- a/src/point-event/point-event.repository.ts
+++ b/src/point-event/point-event.repository.ts
@@ -39,4 +39,8 @@ export class PointEventRepository implements OnModuleInit {
     async getPointEventsByUserId(userid) {
         return (await this.pointEventMapper.find({userid})).toArray();
     }
+
+    async getPointEventsByHash(hash) {
+        return (await this.pointEventMapper.find({hash})).toArray();
+    }
 }

--- a/src/point-event/point-event.service.ts
+++ b/src/point-event/point-event.service.ts
@@ -54,6 +54,9 @@ export class PointEventService {
 
   async rewardAccountConnected(userid:string, platform: string) {
     const hashString = userid + "connectedaccount" + platform;
+    const reward = await this.findOne(hashString);
+    if(reward.length > 0)
+      return reward;
     return await this.create({
       hashString,
       userid,
@@ -76,8 +79,9 @@ export class PointEventService {
     return await this.pointEventRepository.getPointEventsByUserId(userid)
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} pointEvent`;
+  async findOne(hashString: string) {
+    const hash = crypto.createHash('sha256').update(hashString).digest('base64');
+    return await this.pointEventRepository.getPointEventsByHash(hash)
   }
 
   async update(updatePointEventDto: UpdatePointEventDto) {


### PR DESCRIPTION
…ed before.

so this PR checks if the same hashed platform connection reward point event is already in the db before updating it to cassandra.  details are here: https://trello.com/c/MzftPFMZ