### PR TITLE
fix: twitter social badge share link internal error

### DIFF
--- a/public/point-badge/share/twitter.hbs
+++ b/public/point-badge/share/twitter.hbs
@@ -5,7 +5,7 @@
         <meta name="twitter:site" content="@cpsavesoil">
         <meta name="twitter:title" content="Look How Many Points I Have">
         <meta name="twitter:description" content="I have shared a post and earned points. You too share a post to #SaveSoil. http://savesoil.com">
-        <meta name="twitter:image" content="{{base_url}}/point-badge?point={{point}}&total={{total}}&streak={{streak}}&theme={{theme}}&confetti={{confetti}}&random={{random}}">
+        <meta name="twitter:image" content="{{base_url}}/point-badge?point={{point}}&total={{total}}&streak={{streak}}&theme={{theme}}&confetti={{confetti}}&random={{random_number}}">
         <meta name="twitter:image:alt" content="The Points That Will Save Soil">
     </head>
     <body>

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -461,7 +461,7 @@ export class AppController {
             streak: streak,
             theme: theme,
             confetti: confetti,
-            random: Math.floor(Math.random() * 2147483646)
+            random_number: Math.floor(Math.random() * 2147483646)
           })
         );
         return;


### PR DESCRIPTION
for some reason handlebar treat the keyword random as helper and started to give error. the variable random has changed to random_number